### PR TITLE
code autocompletion

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -2,6 +2,9 @@ let currentData = null;
 let editor = null;
 
 function setupEditor() {
+    // Enable Ace language tools
+    ace.require("ace/ext/language_tools");
+    
     // Initialize Ace editor
     editor = ace.edit("code-editor");
     editor.setTheme("ace/theme/xcode");
@@ -11,6 +14,7 @@ function setupEditor() {
         fontSize: "14px",
         showPrintMargin: false,
         highlightActiveLine: true,
+        enableBasicAutocompletion: true,
         enableLiveAutocompletion: true,
         enableSnippets: true,
         tabSize: 4,

--- a/static/script.js
+++ b/static/script.js
@@ -311,5 +311,12 @@ async function visualize() {
     }
 }
 
+document.addEventListener('keydown', function(event) {
+    if (event.ctrlKey && event.key === 'Enter') {
+        event.preventDefault();
+        visualize();
+    }
+});
+
 // Initialize the editor when the page loads
 document.addEventListener('DOMContentLoaded', setupEditor); 

--- a/static/script.js
+++ b/static/script.js
@@ -24,6 +24,8 @@ function setupEditor() {
         showFoldWidgets: true
     });
 
+    editor.setBehavioursEnabled(true);
+
     // Set our custom Timeline mode
     editor.session.setMode("ace/mode/timeline");
 }

--- a/static/script.js
+++ b/static/script.js
@@ -38,6 +38,12 @@ function showError(message, errors = null, errorType = null) {
             errorHtml += '<ul>';
             errors.forEach(error => {
                 errorHtml += `<li>Line ${error.line}, Column ${error.column}: ${error.message}</li>`;
+                editor.getSession().setAnnotations([{
+                  row: error.line - 1,
+                  column: error.column,
+                  text: error.message,
+                  type: "error"
+                }]);
             });
             errorHtml += '</ul>';
         }
@@ -47,6 +53,12 @@ function showError(message, errors = null, errorType = null) {
             errorHtml += '<ul>';
             errors.forEach(error => {
                 const location = error.line ? ` at line ${error.line}${error.column ? `, column ${error.column}` : ''}` : '';
+                editor.getSession().setAnnotations([{
+                  row: error.line - 1,
+                  column: error.column,
+                  text: error.message,
+                  type: "error"
+                }]);
                 errorHtml += `<li>${error.message}${location}</li>`;
             });
             errorHtml += '</ul>';
@@ -73,6 +85,7 @@ function showError(message, errors = null, errorType = null) {
 }
 
 function clearError() {
+    editor.getSession().setAnnotations([]);
     document.getElementById('error-message').style.display = 'none';
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -103,6 +103,36 @@ h2 {
     color: #6c757d;
 }
 
+/* Ace editor syntax highlighting */
+.ace_keyword {
+    color: #8959A8 !important;
+}
+
+.ace_support.ace_function {
+    color: #4271AE !important;
+}
+
+.ace_constant.ace_language {
+    color: #F5871F !important;
+}
+
+.ace_string {
+    color: #718C00 !important;
+}
+
+.ace_numeric {
+    color: #C99E00 !important;
+}
+
+.ace_comment {
+    color: #8E908C !important;
+    font-style: italic;
+}
+
+.ace_operator {
+    color: #3E999F !important;
+}
+
 /* Visualization content styles */
 .visualization-content {
     flex: 1;

--- a/static/timeline-mode.js
+++ b/static/timeline-mode.js
@@ -4,15 +4,21 @@ define('ace/mode/timeline', function(require, exports, module) {
     var oop = require("ace/lib/oop");
     var TextMode = require("ace/mode/text").Mode;
     var TimelineHighlightRules = require("ace/mode/timeline_highlight_rules").TimelineHighlightRules;
+    var TimelineCompletions = require("ace/mode/timeline_completions").TimelineCompletions;
 
     var Mode = function() {
         this.HighlightRules = TimelineHighlightRules;
+        this.$completer = new TimelineCompletions();
     };
     oop.inherits(Mode, TextMode);
 
     (function() {
         this.lineCommentStart = "//";
         this.blockComment = {start: "/*", end: "*/"};
+        
+        this.getCompletions = function(state, session, pos, prefix) {
+            return this.$completer.getCompletions(state, session, pos, prefix);
+        };
         
         this.$id = "ace/mode/timeline";
     }).call(Mode.prototype);
@@ -82,4 +88,133 @@ define('ace/mode/timeline_highlight_rules', function(require, exports, module) {
 
     oop.inherits(TimelineHighlightRules, TextHighlightRules);
     exports.TimelineHighlightRules = TimelineHighlightRules;
+});
+
+define('ace/mode/timeline_completions', function(require, exports, module) {
+    "use strict";
+
+    var oop = require("ace/lib/oop");
+
+    var TimelineCompletions = function() {};
+
+    (function() {
+        this.keywords = [
+            "event",
+            "period",
+            "timeline",
+            "relationship",
+            "main",
+            "export",
+            "if",
+            "else",
+            "for",
+            "in",
+            "modify"
+        ];
+
+        this.properties = [
+            "title",
+            "date",
+            "start",
+            "end",
+            "importance",
+            "from",
+            "to",
+            "type",
+            "year",
+            "month",
+            "day"
+        ];
+
+        this.constants = [
+            "high",
+            "medium",
+            "low",
+            "cause-effect",
+            "contemporaneous",
+            "precedes",
+            "follows",
+            "includes",
+            "excludes",
+            "true",
+            "false",
+            "BCE",
+            "CE"
+        ];
+
+        this.getCompletions = function(state, session, pos, prefix) {
+            var token = session.getTokenAt(pos.row, pos.column);
+            var line = session.getLine(pos.row);
+            var completions = [];
+
+            // Add all possible completions
+            var allWords = [].concat(
+                this.keywords.map(function(word) {
+                    return {
+                        caption: word,
+                        value: word,
+                        meta: "keyword",
+                        score: 1000
+                    };
+                }),
+                this.properties.map(function(word) {
+                    return {
+                        caption: word,
+                        value: word,
+                        meta: "property",
+                        score: 900
+                    };
+                }),
+                this.constants.map(function(word) {
+                    return {
+                        caption: word,
+                        value: word,
+                        meta: "constant",
+                        score: 800
+                    };
+                })
+            );
+
+            // Context-aware completions
+            if (line.trim().endsWith("importance =") || line.trim().endsWith("importance=")) {
+                // Only show importance values
+                return this.constants
+                    .filter(word => ["high", "medium", "low"].includes(word))
+                    .map(word => ({
+                        caption: word,
+                        value: word,
+                        meta: "importance",
+                        score: 1000
+                    }));
+            }
+
+            if (line.trim().endsWith("type =") || line.trim().endsWith("type=")) {
+                // Only show relationship types
+                return this.constants
+                    .filter(word => ["cause-effect", "contemporaneous", "precedes", "follows", "includes", "excludes"].includes(word))
+                    .map(word => ({
+                        caption: word,
+                        value: word,
+                        meta: "relationship type",
+                        score: 1000
+                    }));
+            }
+
+            // Inside a block, suggest properties
+            if (line.trim().endsWith("{")) {
+                return this.properties.map(word => ({
+                    caption: word,
+                    value: word + " = ",
+                    meta: "property",
+                    score: 1000
+                }));
+            }
+
+            // Default to all completions
+            return allWords;
+        };
+
+    }).call(TimelineCompletions.prototype);
+
+    exports.TimelineCompletions = TimelineCompletions;
 }); 

--- a/static/timeline-mode.js
+++ b/static/timeline-mode.js
@@ -5,10 +5,12 @@ define('ace/mode/timeline', function(require, exports, module) {
     var TextMode = require("ace/mode/text").Mode;
     var TimelineHighlightRules = require("ace/mode/timeline_highlight_rules").TimelineHighlightRules;
     var TimelineCompletions = require("ace/mode/timeline_completions").TimelineCompletions;
+    var CstyleBehaviour = require("ace/mode/behaviour/cstyle").CstyleBehaviour;
 
     var Mode = function() {
         this.HighlightRules = TimelineHighlightRules;
         this.$completer = new TimelineCompletions();
+        this.$behaviour = new CstyleBehaviour();
     };
     oop.inherits(Mode, TextMode);
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
             <div class="editor-wrapper">
                 <div id="code-editor">{{ default_timeline }}</div>
             </div>
-            <button onclick="visualize()" class="button-visualize">Visualize</button>
+            <button onclick="visualize()" class="button-visualize">Visualize (Ctrl+Enter)</button>
         </div>
         <div class="visualization-section">
             <div class="result">

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,16 +8,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/ace.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/theme-xcode.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/mode-text.min.js"></script>
-    <script src="static/timeline-mode.js"></script>
-    <style>
-        .ace_keyword { color: #8959A8 !important; }
-        .ace_support.ace_function { color: #4271AE !important; }
-        .ace_constant.ace_language { color: #F5871F !important; }
-        .ace_string { color: #718C00 !important; }
-        .ace_numeric { color: #C99E00 !important; }
-        .ace_comment { color: #8E908C !important; font-style: italic; }
-        .ace_operator { color: #3E999F !important; }
-    </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/ext-language_tools.js"></script>
+    <script src="../static/timeline-mode.js"></script>
 </head>
 <body>
     <div class="container">

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Timeline DSL Visualizer</title>
-    <link rel="stylesheet" href="static/styles.css">
+    <link rel="stylesheet" href="../static/styles.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/ace.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/theme-xcode.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.6/mode-text.min.js"></script>
@@ -49,6 +49,6 @@
             </div>
         </div>
     </div>
-    <script src="static/script.js"></script>
+    <script src="../static/script.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
- use ace language tools to add code completion by defining tokens and matching them
- add scoring for identifying most important tokens (best suggestions) based on location and token type
- enable autocompletion in editor options

additional:
- add error as annotation to code editor (similar to error highlighting) by using the error raised by the python app (no additional JS parsing)
- add event listener for ctrl+enter for code execution
- enabled behaviours for character auto pairing using C base behaviours (pre-made in Ace)
- small styles refactoring


closes #5 